### PR TITLE
Add missing include for VxWorks build.

### DIFF
--- a/src/catch2/internal/catch_sharding.hpp
+++ b/src/catch2/internal/catch_sharding.hpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_session.hpp>
 
 #include <cmath>
+#include <algorithm>
 
 namespace Catch {
 


### PR DESCRIPTION
std::min is defined in algorithm. It appears to be transitively included for most platforms. For VxWorks however this explicit include is required.

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
